### PR TITLE
K8S-777: Cherry-pick fixes for cinder detach bugs

### DIFF
--- a/pkg/cloudprovider/providers/openstack/BUILD
+++ b/pkg/cloudprovider/providers/openstack/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
+        "//pkg/volume/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack:go_default_library",

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -320,6 +320,22 @@ func mapNodeNameToServerName(nodeName types.NodeName) string {
 	return string(nodeName)
 }
 
+// getNodeNameByID maps instanceid to types.NodeName
+func (os *OpenStack) GetNodeNameByID(instanceID string) (types.NodeName, error) {
+	client, err := os.NewComputeV2()
+	var nodeName types.NodeName
+	if err != nil {
+		return nodeName, err
+	}
+
+	server, err := servers.Get(client, instanceID).Extract()
+	if err != nil {
+		return nodeName, err
+	}
+	nodeName = mapServerToNodeName(server)
+	return nodeName, nil
+}
+
 // mapServerToNodeName maps an OpenStack Server to a k8s NodeName
 func mapServerToNodeName(server *servers.Server) types.NodeName {
 	// Node names are always lowercase, and (at least)
@@ -347,11 +363,14 @@ func foreachServer(client *gophercloud.ServiceClient, opts servers.ListOptsBuild
 	return err
 }
 
-func getServerByName(client *gophercloud.ServiceClient, name types.NodeName) (*servers.Server, error) {
+func getServerByName(client *gophercloud.ServiceClient, name types.NodeName, showOnlyActive bool) (*servers.Server, error) {
 	opts := servers.ListOpts{
-		Name:   fmt.Sprintf("^%s$", regexp.QuoteMeta(mapNodeNameToServerName(name))),
-		Status: "ACTIVE",
+		Name: fmt.Sprintf("^%s$", regexp.QuoteMeta(mapNodeNameToServerName(name))),
 	}
+	if showOnlyActive {
+		opts.Status = "ACTIVE"
+	}
+
 	pager := servers.List(client, opts)
 
 	serverList := make([]servers.Server, 0, 1)
@@ -433,7 +452,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 }
 
 func getAddressesByName(client *gophercloud.ServiceClient, name types.NodeName) ([]v1.NodeAddress, error) {
-	srv, err := getServerByName(client, name)
+	srv, err := getServerByName(client, name, true)
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +615,7 @@ func (os *OpenStack) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Z
 		return cloudprovider.Zone{}, err
 	}
 
-	srv, err := getServerByName(compute, nodeName)
+	srv, err := getServerByName(compute, nodeName, true)
 	if err != nil {
 		if err == ErrNotFound {
 			return cloudprovider.Zone{}, cloudprovider.InstanceNotFound

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -103,7 +103,7 @@ func (i *Instances) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddre
 
 // ExternalID returns the cloud provider ID of the specified instance (deprecated).
 func (i *Instances) ExternalID(name types.NodeName) (string, error) {
-	srv, err := getServerByName(i.compute, name)
+	srv, err := getServerByName(i.compute, name, true)
 	if err != nil {
 		if err == ErrNotFound {
 			return "", cloudprovider.InstanceNotFound
@@ -151,7 +151,7 @@ func (os *OpenStack) InstanceID() (string, error) {
 
 // InstanceID returns the cloud provider ID of the specified instance.
 func (i *Instances) InstanceID(name types.NodeName) (string, error) {
-	srv, err := getServerByName(i.compute, name)
+	srv, err := getServerByName(i.compute, name, true)
 	if err != nil {
 		if err == ErrNotFound {
 			return "", cloudprovider.InstanceNotFound
@@ -184,7 +184,7 @@ func (i *Instances) InstanceTypeByProviderID(providerID string) (string, error) 
 
 // InstanceType returns the type of the specified instance.
 func (i *Instances) InstanceType(name types.NodeName) (string, error) {
-	srv, err := getServerByName(i.compute, name)
+	srv, err := getServerByName(i.compute, name, true)
 
 	if err != nil {
 		return "", err

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -551,7 +551,7 @@ func getNodeSecurityGroupIDForLB(compute *gophercloud.ServiceClient, nodes []*v1
 
 	for _, node := range nodes {
 		nodeName := types.NodeName(node.Name)
-		srv, err := getServerByName(compute, nodeName)
+		srv, err := getServerByName(compute, nodeName, true)
 		if err != nil {
 			return nodeSecurityGroupIDs.List(), err
 		}

--- a/pkg/cloudprovider/providers/openstack/openstack_routes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes.go
@@ -295,7 +295,7 @@ func (r *Routes) DeleteRoute(clusterName string, route *cloudprovider.Route) err
 }
 
 func getPortIDByIP(compute *gophercloud.ServiceClient, targetNode types.NodeName, ipAddress string) (string, error) {
-	srv, err := getServerByName(compute, targetNode)
+	srv, err := getServerByName(compute, targetNode, true)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -602,6 +602,32 @@ func (os *OpenStack) DiskIsAttached(instanceID, volumeID string) (bool, error) {
 	return instanceID == volume.AttachedServerId, nil
 }
 
+
+// SafeToDetachNode queries if a node is safe to detach volume
+func (os *OpenStack) SafeToDetachNode(nodeName types.NodeName) (bool, error) {
+	cClient, err := os.NewComputeV2()
+	if err != nil {
+		return false, err
+	}
+	srv, err := getServerByName(cClient, nodeName, false)
+	if err != nil {
+		if err == ErrNotFound {
+			// instance not found anymore in cloudprovider, assume that cinder is safe to detach
+			return true, nil
+		} else {
+			return false, err
+		}
+	}
+	glog.V(4).Infof("Node %s status %s", nodeName, srv.Status)
+	// all states listed here where it is safe to detach drive without problems
+	if srv.Status == "SHUTOFF" {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+
 // DiskIsAttachedByName queries if a volume is attached to a compute instance by name
 func (os *OpenStack) DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error) {
 	cClient, err := os.NewComputeV2()

--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -105,6 +105,9 @@ type DesiredStateOfWorld interface {
 	// Mark multiattach error as reported to prevent spamming multiple
 	// events for same error
 	SetMultiAttachError(v1.UniqueVolumeName, k8stypes.NodeName)
+
+	// is node in state where it is safe to detach volumes
+	SafeToDetach(nodeName k8stypes.NodeName) bool
 }
 
 // VolumeToAttach represents a volume that should be attached to a node.
@@ -158,6 +161,9 @@ type nodeManaged struct {
 	// keepTerminatedPodVolumes determines if for terminated pods(on this node) - volumes
 	// should be kept mounted and attached.
 	keepTerminatedPodVolumes bool
+
+	// safeToDetach determines if it is safe to detach volume - for instance if node is going to deleted from cluster
+	safeToDetach bool
 }
 
 // The volume object represents a volume that should be attached to a node.
@@ -200,6 +206,7 @@ func (dsw *desiredStateOfWorld) AddNode(nodeName k8stypes.NodeName, keepTerminat
 			nodeName:                 nodeName,
 			volumesToAttach:          make(map[v1.UniqueVolumeName]volumeToAttach),
 			keepTerminatedPodVolumes: keepTerminatedPodVolumes,
+			safeToDetach:             false,
 		}
 	}
 }
@@ -267,10 +274,36 @@ func (dsw *desiredStateOfWorld) DeleteNode(nodeName k8stypes.NodeName) error {
 	}
 
 	if len(nodeObj.volumesToAttach) > 0 {
+		// query real status of node
+		// if node is in safe mode mark as safeToDetach
+		safeToDetach := true
+		for _, volumeObj := range nodeObj.volumesToAttach {
+			volumePlugin, err := dsw.volumePluginMgr.FindAttachablePluginBySpec(volumeObj.spec)
+			if err != nil || volumePlugin == nil {
+				return fmt.Errorf(
+					"failed to get volumePlugin from volumeSpec for volume %q err=%v",
+					volumeObj.spec.Name(),
+					err)
+			}
+			volumeDetacher, err := volumePlugin.NewDetacher()
+			if err != nil {
+				return fmt.Errorf("failed to init NewDetacher err=%v", err)
+			}
+			safe, err := volumeDetacher.SafeToDetachFromNode(nodeName)
+			if err != nil {
+				return fmt.Errorf("failed to get SafeToDetachFromNode err=%v", err)
+			}
+			if !safe {
+				safeToDetach = false
+			}
+		}
+		nodeObj.safeToDetach = safeToDetach
+		dsw.nodesManaged[nodeName] = nodeObj
 		return fmt.Errorf(
-			"failed to delete node %q from list of nodes managed by attach/detach controller--the node still contains %v volumes in its list of volumes to attach",
+			"failed to delete node %q from list of nodes managed by attach/detach controller--the node still contains %v volumes in its list of volumes to attach. SafeToDetach: %t",
 			nodeName,
-			len(nodeObj.volumesToAttach))
+			len(nodeObj.volumesToAttach),
+			safeToDetach)
 	}
 
 	delete(
@@ -316,6 +349,18 @@ func (dsw *desiredStateOfWorld) NodeExists(nodeName k8stypes.NodeName) bool {
 
 	_, nodeExists := dsw.nodesManaged[nodeName]
 	return nodeExists
+}
+
+func (dsw *desiredStateOfWorld) SafeToDetach(nodeName k8stypes.NodeName) bool {
+
+	// do we need lock here?
+	//dsw.RLock()
+	//defer dsw.RUnlock()
+	nodeObj, nodeExists := dsw.nodesManaged[nodeName]
+	if nodeExists {
+		return nodeObj.safeToDetach
+	}
+	return false
 }
 
 func (dsw *desiredStateOfWorld) VolumeExists(

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -197,8 +197,10 @@ func (rc *reconciler) reconcile() {
 			}
 			// Check whether timeout has reached the maximum waiting time
 			timeout := elapsedTime > rc.maxWaitForUnmountDuration
-			// Check whether volume is still mounted. Skip detach if it is still mounted unless timeout
-			if attachedVolume.MountedByNode && !timeout {
+			safeToDetach := rc.desiredStateOfWorld.SafeToDetach(attachedVolume.NodeName)
+
+			// Check whether volume is still mounted. Skip detach if it is still mounted unless timeout or node is safe to detach
+			if attachedVolume.MountedByNode && !timeout && !safeToDetach {
 				glog.V(12).Infof(attachedVolume.GenerateMsgDetailed("Cannot detach volume because it is still mounted", ""))
 				continue
 			}

--- a/pkg/volume/aws_ebs/attacher.go
+++ b/pkg/volume/aws_ebs/attacher.go
@@ -263,6 +263,11 @@ func (detacher *awsElasticBlockStoreDetacher) Detach(volumeName string, nodeName
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *awsElasticBlockStoreDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *awsElasticBlockStoreDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -299,6 +299,12 @@ func (d *azureDiskDetacher) Detach(diskURI string, nodeName types.NodeName) erro
 	return err
 }
 
+
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (d *azureDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 // UnmountDevice unmounts the volume on the node
 func (detacher *azureDiskDetacher) UnmountDevice(deviceMountPath string) error {
 	err := volumeutil.UnmountPath(deviceMountPath, detacher.plugin.host.GetMounter(detacher.plugin.GetPluginName()))

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -387,6 +387,11 @@ func (detacher *cinderDiskDetacher) Detach(volumeName string, nodeName types.Nod
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *cinderDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return detacher.cinderProvider.SafeToDetachNode(nodeName)
+}
+
 func (detacher *cinderDiskDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/cinder/attacher_test.go
+++ b/pkg/volume/cinder/attacher_test.go
@@ -132,7 +132,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Attach_Positive",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, false, nil},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, false, nil},
 			attach:           attachCall{instanceID, volumeID, "", nil},
 			diskPath:         diskPathCall{instanceID, volumeID, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
@@ -147,7 +147,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Attach_Positive_AlreadyAttached",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, true, nil},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, true, nil},
 			diskPath:         diskPathCall{instanceID, volumeID, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
@@ -173,7 +173,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Attach_Negative",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, false, diskCheckError},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, false, diskCheckError},
 			attach:           attachCall{instanceID, volumeID, "/dev/sda", attachError},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
@@ -187,7 +187,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Attach_Negative_DiskPatchFails",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, false, nil},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, false, nil},
 			attach:           attachCall{instanceID, volumeID, "", nil},
 			diskPath:         diskPathCall{instanceID, volumeID, "", diskPathError},
 			test: func(testcase *testcase) (string, error) {
@@ -201,7 +201,7 @@ func TestAttachDetach(t *testing.T) {
 		{
 			name:             "VolumesAreAttached_Positive",
 			instanceID:       instanceID,
-			disksAreAttached: disksAreAttachedCall{instanceID, []string{volumeID}, map[string]bool{volumeID: true}, nil},
+			disksAreAttached: disksAreAttachedCall{instanceID, nodeName, []string{volumeID}, map[string]bool{volumeID: true}, nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
 				attachments, err := attacher.VolumesAreAttached([]*volume.Spec{spec}, nodeName)
@@ -214,7 +214,7 @@ func TestAttachDetach(t *testing.T) {
 		{
 			name:             "VolumesAreAttached_Negative",
 			instanceID:       instanceID,
-			disksAreAttached: disksAreAttachedCall{instanceID, []string{volumeID}, map[string]bool{volumeID: false}, nil},
+			disksAreAttached: disksAreAttachedCall{instanceID, nodeName, []string{volumeID}, map[string]bool{volumeID: false}, nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
 				attachments, err := attacher.VolumesAreAttached([]*volume.Spec{spec}, nodeName)
@@ -227,7 +227,7 @@ func TestAttachDetach(t *testing.T) {
 		{
 			name:             "VolumesAreAttached_CinderFailed",
 			instanceID:       instanceID,
-			disksAreAttached: disksAreAttachedCall{instanceID, []string{volumeID}, nil, disksCheckError},
+			disksAreAttached: disksAreAttachedCall{instanceID, nodeName, []string{volumeID}, nil, disksCheckError},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
 				attachments, err := attacher.VolumesAreAttached([]*volume.Spec{spec}, nodeName)
@@ -242,7 +242,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Detach_Positive",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, true, nil},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, true, nil},
 			detach:           detachCall{instanceID, volumeID, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
@@ -255,7 +255,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Detach_Positive_AlreadyDetached",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, false, nil},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
 				return "", detacher.Detach(volumeID, nodeName)
@@ -267,7 +267,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Detach_Positive_CheckFails",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, false, diskCheckError},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, false, diskCheckError},
 			detach:           detachCall{instanceID, volumeID, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
@@ -280,7 +280,7 @@ func TestAttachDetach(t *testing.T) {
 			name:             "Detach_Negative",
 			instanceID:       instanceID,
 			operationPending: operationPendingCall{volumeID, false, done, nil},
-			diskIsAttached:   diskIsAttachedCall{instanceID, volumeID, false, diskCheckError},
+			diskIsAttached:   diskIsAttachedCall{instanceID, nodeName, volumeID, false, diskCheckError},
 			detach:           detachCall{instanceID, volumeID, detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
@@ -426,6 +426,7 @@ type operationPendingCall struct {
 
 type diskIsAttachedCall struct {
 	instanceID string
+	nodeName   types.NodeName
 	volumeID   string
 	isAttached bool
 	ret        error
@@ -440,6 +441,7 @@ type diskPathCall struct {
 
 type disksAreAttachedCall struct {
 	instanceID  string
+	nodeName    types.NodeName
 	volumeIDs   []string
 	areAttached map[string]bool
 	ret         error
@@ -572,6 +574,46 @@ func (testcase *testcase) ShouldTrustDevicePath() bool {
 	return true
 }
 
+func (testcase *testcase) DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error) {
+	expected := &testcase.diskIsAttached
+	instanceID := expected.instanceID
+	// If testcase call DetachDisk*, return false
+	if *testcase.attachOrDetach == detachStatus {
+		return false, instanceID, nil
+	}
+
+	// If testcase call AttachDisk*, return true
+	if *testcase.attachOrDetach == attachStatus {
+		return true, instanceID, nil
+	}
+
+	if expected.nodeName != nodeName {
+		testcase.t.Errorf("Unexpected DiskIsAttachedByName call: expected nodename %s, got %s", expected.nodeName, nodeName)
+		return false, instanceID, errors.New("Unexpected DiskIsAttachedByName call: wrong nodename")
+	}
+
+	if expected.volumeID == "" && expected.instanceID == "" {
+		// testcase.diskIsAttached looks uninitialized, test did not expect to
+		// call DiskIsAttached
+		testcase.t.Errorf("Unexpected DiskIsAttachedByName call!")
+		return false, instanceID, errors.New("Unexpected DiskIsAttachedByName call!")
+	}
+
+	if expected.volumeID != volumeID {
+		testcase.t.Errorf("Unexpected DiskIsAttachedByName call: expected volumeID %s, got %s", expected.volumeID, volumeID)
+		return false, instanceID, errors.New("Unexpected DiskIsAttachedByName call: wrong volumeID")
+	}
+
+	if expected.instanceID != instanceID {
+		testcase.t.Errorf("Unexpected DiskIsAttachedByName call: expected instanceID %s, got %s", expected.instanceID, instanceID)
+		return false, instanceID, errors.New("Unexpected DiskIsAttachedByName call: wrong instanceID")
+	}
+
+	glog.V(4).Infof("DiskIsAttachedByName call: %s, %s, returning %v, %v", volumeID, nodeName, expected.isAttached, expected.instanceID, expected.ret)
+
+	return expected.isAttached, expected.instanceID, expected.ret
+}
+
 func (testcase *testcase) CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, bool, error) {
 	return "", "", false, errors.New("Not implemented")
 }
@@ -622,6 +664,36 @@ func (testcase *testcase) DisksAreAttached(instanceID string, volumeIDs []string
 	}
 
 	glog.V(4).Infof("DisksAreAttached call: %v, %s, returning %v, %v", volumeIDs, instanceID, expected.areAttached, expected.ret)
+
+	return expected.areAttached, expected.ret
+}
+
+func (testcase *testcase) DisksAreAttachedByName(nodeName types.NodeName, volumeIDs []string) (map[string]bool, error) {
+	expected := &testcase.disksAreAttached
+	areAttached := make(map[string]bool)
+
+	instanceID := expected.instanceID
+	if expected.nodeName != nodeName {
+		testcase.t.Errorf("Unexpected DisksAreAttachedByName call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+		return areAttached, errors.New("Unexpected DisksAreAttachedByName call: wrong nodename")
+	}
+	if len(expected.volumeIDs) == 0 && expected.instanceID == "" {
+		// testcase.volumeIDs looks uninitialized, test did not expect to call DisksAreAttached
+		testcase.t.Errorf("Unexpected DisksAreAttachedByName call!")
+		return areAttached, errors.New("Unexpected DisksAreAttachedByName call")
+	}
+
+	if !reflect.DeepEqual(expected.volumeIDs, volumeIDs) {
+		testcase.t.Errorf("Unexpected DisksAreAttachedByName call: expected volumeIDs %v, got %v", expected.volumeIDs, volumeIDs)
+		return areAttached, errors.New("Unexpected DisksAreAttachedByName call: wrong volumeID")
+	}
+
+	if expected.instanceID != instanceID {
+		testcase.t.Errorf("Unexpected DisksAreAttachedByName call: expected instanceID %s, got %s", expected.instanceID, instanceID)
+		return areAttached, errors.New("Unexpected DisksAreAttachedByName call: wrong instanceID")
+	}
+
+	glog.V(4).Infof("DisksAreAttachedByName call: %v, %s, returning %v, %v", volumeIDs, nodeName, expected.areAttached, expected.ret)
 
 	return expected.areAttached, expected.ret
 }

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -52,7 +52,8 @@ type CinderProvider interface {
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)
 	OperationPending(diskName string) (bool, string, error)
 	DiskIsAttached(instanceID, volumeID string) (bool, error)
-	DisksAreAttached(instanceID string, volumeIDs []string) (map[string]bool, error)
+	DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error)
+	DisksAreAttachedByName(nodeName types.NodeName, volumeIDs []string) (map[string]bool, error)
 	ShouldTrustDevicePath() bool
 	Instances() (cloudprovider.Instances, bool)
 	ExpandVolume(volumeID string, oldSize resource.Quantity, newSize resource.Quantity) (resource.Quantity, error)

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -55,6 +55,7 @@ type CinderProvider interface {
 	DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error)
 	DisksAreAttachedByName(nodeName types.NodeName, volumeIDs []string) (map[string]bool, error)
 	ShouldTrustDevicePath() bool
+	SafeToDetachNode(nodeName types.NodeName) (bool, error) 
 	Instances() (cloudprovider.Instances, bool)
 	ExpandVolume(volumeID string, oldSize resource.Quantity, newSize resource.Quantity) (resource.Quantity, error)
 }

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -221,6 +221,11 @@ func (c *csiAttacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return c.waitForVolumeDetachment(volID, attachID)
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (c *csiAttacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (c *csiAttacher) waitForVolumeDetachment(volumeHandle, attachID string) error {
 	glog.V(4).Info(log("probing for updates from CSI driver for [attachment.ID=%v]", attachID))
 

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -141,6 +141,11 @@ func (detacher *fcDetacher) Detach(volumeName string, nodeName types.NodeName) e
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *fcDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *fcDetacher) UnmountDevice(deviceMountPath string) error {
 	// Specify device name for DetachDisk later
 	devName, _, err := mount.GetDeviceNameFromMount(detacher.mounter, deviceMountPath)

--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -19,7 +19,6 @@ package flexvolume
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,18 +42,6 @@ func (d *flexVolumeDetacher) Detach(volumeName string, hostName types.NodeName) 
 	_, err := call.Run()
 	if isCmdNotSupportedErr(err) {
 		return (*detacherDefaults)(d).Detach(volumeName, hostName)
-	}
-	return err
-}
-
-// WaitForDetach is part of the volume.Detacher interface.
-func (d *flexVolumeDetacher) WaitForDetach(devicePath string, timeout time.Duration) error {
-	call := d.plugin.NewDriverCallWithTimeout(waitForDetachCmd, timeout)
-	call.Append(devicePath)
-
-	_, err := call.Run()
-	if isCmdNotSupportedErr(err) {
-		return (*detacherDefaults)(d).WaitForDetach(devicePath, timeout)
 	}
 	return err
 }

--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -46,6 +46,11 @@ func (d *flexVolumeDetacher) Detach(volumeName string, hostName types.NodeName) 
 	return err
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (d *flexVolumeDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 // UnmountDevice is part of the volume.Detacher interface.
 func (d *flexVolumeDetacher) UnmountDevice(deviceMountPath string) error {
 

--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -39,7 +39,6 @@ const (
 	mountDeviceCmd   = "mountdevice"
 
 	detachCmd        = "detach"
-	waitForDetachCmd = "waitfordetach"
 	unmountDeviceCmd = "unmountdevice"
 
 	mountCmd   = "mount"

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -272,6 +272,11 @@ func (detacher *gcePersistentDiskDetacher) Detach(volumeName string, nodeName ty
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *gcePersistentDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *gcePersistentDiskDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.host.GetMounter(gcePersistentDiskPluginName))
 }

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -142,6 +142,11 @@ func (detacher *iscsiDetacher) Detach(volumeName string, nodeName types.NodeName
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *iscsiDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *iscsiDetacher) UnmountDevice(deviceMountPath string) error {
 	unMounter := detacher.volumeSpecToUnmounter(detacher.mounter)
 	err := detacher.manager.DetachDisk(*unMounter, deviceMountPath)

--- a/pkg/volume/photon_pd/attacher.go
+++ b/pkg/volume/photon_pd/attacher.go
@@ -268,6 +268,11 @@ func (detacher *photonPersistentDiskDetacher) Detach(volumeName string, nodeName
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *photonPersistentDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *photonPersistentDiskDetacher) WaitForDetach(devicePath string, timeout time.Duration) error {
 	ticker := time.NewTicker(checkSleepDuration)
 	defer ticker.Stop()

--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -223,3 +223,9 @@ func (detacher *rbdDetacher) UnmountDevice(deviceMountPath string) error {
 func (detacher *rbdDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return nil
 }
+
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *rbdDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -245,6 +245,10 @@ type Detacher interface {
 	// should only be called once all bind mounts have been
 	// unmounted.
 	UnmountDevice(deviceMountPath string) error
+
+	// SafeToDetachFromNode shows is the node in safe mode to detach volume
+	// for instance if node is shutdowned in cloud provider it is safe to detach without waiting
+	SafeToDetachFromNode(nodeName types.NodeName) (bool, error)
 }
 
 // NewDeletedVolumeInUseError returns a new instance of DeletedVolumeInUseError

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -277,6 +277,11 @@ func (detacher *vsphereVMDKDetacher) Detach(volumeName string, nodeName types.No
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *vsphereVMDKDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }


### PR DESCRIPTION
This patchset includes three cherry-picks:

* `de14987` fixes original cinder volume detach problem described in K8S-777 and https://github.com/kubernetes/kubernetes/issues/57497
* `a422f00` resolves  merge conflict between  `de14987` and `91e660f`
* `91e660f` is from a WIP PR against kubernetes master and addresses an undesirable timeout between node failure and pod detach (described further in https://github.com/kubernetes/kubernetes/issues/58079)

Also worth noting is the new branch I have pushed to this repo, against which this PR is being submitted. I called it `managed-k8s/release-1.9.6` to reflect that it is specific to our managed k8s service and is a release branch starting at upstreams' `v1.9.6` release.
